### PR TITLE
Add missing section title heading levels

### DIFF
--- a/sphinx_asciidoc/writer.py
+++ b/sphinx_asciidoc/writer.py
@@ -54,10 +54,12 @@ def toansi(text):
 
 sectionEquals = { # Stores values for different section levels
     -1: '',
-     0: '= ', #title
-     1: '== ', # section
-     2: '=== ', # subsection
-     3: '==== ', # subsubsection
+     0: '= ', # Document Title (Level 0)
+     1: '== ', # Level 1 Section Title
+     2: '=== ', # Level 2 Section Title
+     3: '==== ', # Level 3 Section Title
+     4: '===== ', # Level 4 Section Title
+     5: '====== ', # Level 5 Section Title
     }
 
 


### PR DESCRIPTION
- Add levels 4 and 5 according to AsciiDoc [syntax quick reference](https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/)
- Update comments to match that page